### PR TITLE
Update plot_height_multipanel.py

### DIFF
--- a/src/ch02/plot_height_multipanel.py
+++ b/src/ch02/plot_height_multipanel.py
@@ -18,7 +18,7 @@ matplotlib.use('Agg')
 matplotlib.rcParams.update({'font.size': 16})
 
 # read data into a list
-data = [line.rstrip().split() for line in open(input_file).readlines()]
+data = [line.rstrip().split() for line in open(input_file, encoding='utf-16').readlines()]
 
 time = [float(line[0]) for line in data]
 h = np.array([[float(x) for x in line[1:]] for line in data])


### PR DESCRIPTION
This solved the BOM issue for reading the file in Python.
On windows OS, ./tsunami > tsumani_output.txt is writing the file in utf-16 which causes an error if file is opened with utf-8 BOM signature.